### PR TITLE
[FIX]:회원가입 안되던 오류 수정 ( 회원가입 시 세션 여부에 따른 분기문 삭제 )

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.21.1",
     "react-toastify": "^11.0.5",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "toastify": "^2.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/pages/User/MyPage.jsx
+++ b/client/src/pages/User/MyPage.jsx
@@ -12,7 +12,7 @@ function MyPage() {
     "/images/profile4.png",
     "/images/profile5.png",
   ];
-  const [selectedImage, setSelectedImage] = useState(currentUser.user_image);
+  // const [selectedImage, setSelectedImage] = useState(currentUser.user_image);
 
   const [isNicknameEditable, setIsNicknameEditable] = useState(false);
   const [nickname, setNickname] = useState("");

--- a/server/src/controllers/meetingDataController.js
+++ b/server/src/controllers/meetingDataController.js
@@ -1,4 +1,4 @@
-const db = require("../models/db_users");
+const db = require("../models/meetingly_db");
 const { v4: uuidv4 } = require("uuid");
 
 // [GET] 특정 회의 상세 정보 조회

--- a/server/src/controllers/summaryController.js
+++ b/server/src/controllers/summaryController.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const axios = require("axios");
 const { v4: uuidv4 } = require("uuid");
-const db = require("../models/db_users");
+const db = require("../models/meetingly_db");
 
 const handleUploadRecord = async (req, res) => {
   const { roomId, isCreator } = req.body;

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -189,9 +189,10 @@ exports.checkNicknameDuplicate = async (req, res) => {
 exports.registerUser = async (req, res) => {
   const { name, email, password, nickname } = req.body;
 
-  if (!req.session.isEmailVerified) {
-    return res.status(403).json({ message: "이메일 인증이 필요합니다" });
-  }
+  // if (!req.session.isEmailVerified) {
+  //   return res.status(403).json({ message: "이메일 인증이 필요합니다" });
+  // }
+  
   try {
     // 비밀번호 해시
     const hashedPassword = await bcrypt.hash(password, 10);


### PR DESCRIPTION
## 📄 Description

> 작업 내용 요약 : 사용자가 인풋창에 입력한 이메일 인증번호와 세션에 저장된 인증번호 비교 후 같으면, 인증을 마친 뒤 해당 세션을 지우는 로직을 넣어두었음에도, 회원가입에서 세션이 있어야만 완료되도록 조건을 걸어놓았었으므로.. 회원가입 로직 상에서 세션 여부 분기문 코드 삭제 후 회원가입 가능하도록 수정

## 📌 구현 내용

- [ ] 구현한 기능을 적습니다 (1)
- [ ] 구현한 기능을 적습니다 (2)

## ✅ PR 포인트

없으면 생략 가능
